### PR TITLE
Support reading HLSConfig from yml files in tests

### DIFF
--- a/test/convert-keras-models.sh
+++ b/test/convert-keras-models.sh
@@ -55,7 +55,7 @@ fi
 
 for line in "${model_line[@]}"
 do
-   params=("" "" "" "" "" "" "")
+   params=("" "" "" "" "" "" "" "")
    if [[ ${line} = *[![:space:]]* ]] && ! [[ "${line}" = \#* ]] ; then
       IFS=" " read -ra model_def <<< "${line}"
       for (( i=1; i<"${#model_def[@]}"; i++ ));
@@ -66,10 +66,11 @@ do
          if [[ "${model_def[$i]}" == r:* ]] ; then params[3]="-r ${model_def[$i]:2} "; fi
          if [[ "${model_def[$i]}" == s:* ]] ; then params[4]="-g ${model_def[$i]:2} "; fi
          if [[ "${model_def[$i]}" == i:* ]] ; then params[5]="-t ${model_def[$i]:2} "; fi
+         if [[ "${model_def[$i]}" == y:* ]] ; then params[6]="-y ${model_def[$i]:2} "; fi
       done
-      params[6]=${model_def[0]}
+      params[7]=${model_def[0]}
 
-      cmd="./keras-to-hls.sh ${dir} ${params[0]}${params[1]}${params[2]}${params[3]}${params[4]}${params[5]}${params[6]}"
+      cmd="./keras-to-hls.sh ${dir} ${params[0]}${params[1]}${params[2]}${params[3]}${params[4]}${params[5]}${params[6]}${params[7]}"
 
       ${exec} "${cmd}"
    fi

--- a/test/keras-models.txt
+++ b/test/keras-models.txt
@@ -1,7 +1,7 @@
 # Keras models from examples directory that will be used for testing
 #
 # Synthax:
-#    MODEL_NAME[:WEIGHTS_FILE] [x:XILINXPART] [c:CLOCK_PERIOD] [io:s] [r:REUSE_FACTOR] [t:AP_TYPE] [s:STRATEGY]
+#    MODEL_NAME[:WEIGHTS_FILE] [x:XILINXPART] [c:CLOCK_PERIOD] [io:s] [r:REUSE_FACTOR] [t:AP_TYPE] [s:STRATEGY] [y:CONFIG_FILE]
 # where
 #    MODEL_NAME - Name of the file containing json model (without ".json")
 #    WEIGHTS_FILE - Name of the HDF5 file containing model weights (without ".h5")
@@ -11,6 +11,7 @@
 #    r:REUSE_FACTOR - Reuse factor
 #    s:STRATEGY - Latency-optimized or Resource-optimized strategy
 #    t:AP_TYPE - Default precision
+#    y:CONFIG_FILE - YAML config file to copy HLSConfig from
 #
 # Lines starting with "#" are ignored.
 #
@@ -26,7 +27,7 @@ KERAS_3layer_batch_norm
 KERAS_3layer_binary_smaller
 KERAS_3layer_ternary_small
  
-garnet_1layer r:16
+garnet_1layer x:xcku115-flvb2104-2-i y:garnet_1layer_config 
 
 # Resource strategy
 KERAS_3layer r:2 s:Resource


### PR DESCRIPTION
Testing new QKeras support requires supplying an `HLSConfig` through .yml config file. This PR adds the ability to do that to test scripts. An example with GarNet is included. From the provided yml, only HLSConfig is read, the rest is ignored. This is because config files tend to include relative paths to models, so they can't be used directly when changing the test directory.